### PR TITLE
(#8) Allow clients to request full validation be disabled

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -20,6 +20,14 @@ func IsSecure() bool {
 	return Secure == "true"
 }
 
+// ClientStrictValidation gives hints to the protocol implementations that
+// a client does not wish to be fully validated, this is because validation
+// can often be very slow so clients can elect to disable that.
+//
+// It's not mandatory for a specific version of implementation of the protocol
+// to do anything with this, so it's merely a hint
+var ClientStrictValidation = true
+
 // Additional to these the package for a specific version must also provide these constructors
 // with signature matching those in v1/constructors.go these are in use by mcollective/protocol.gos
 

--- a/protocol/v1/reply.go
+++ b/protocol/v1/reply.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/choria-io/go-protocol/protocol"
 )
 
 type reply struct {
@@ -100,6 +102,10 @@ func (r *reply) Version() string {
 
 // IsValidJSON validates the given JSON data against the schema
 func (r *reply) IsValidJSON(data string) (err error) {
+	if !protocol.ClientStrictValidation {
+		return nil
+	}
+
 	_, errors, err := schemas.Validate(schemas.ReplyV1, data)
 	if err != nil {
 		err = fmt.Errorf("Could not validate Reply JSON data: %s", err.Error())

--- a/protocol/v1/security_reply.go
+++ b/protocol/v1/security_reply.go
@@ -85,6 +85,10 @@ func (r *secureReply) Version() string {
 
 // IsValidJSON validates the given JSON data against the schema
 func (r *secureReply) IsValidJSON(data string) (err error) {
+	if !protocol.ClientStrictValidation {
+		return nil
+	}
+
 	_, errors, err := schemas.Validate(schemas.SecureReplyV1, data)
 	if err != nil {
 		err = fmt.Errorf("Could not validate SecureReply JSON data: %s", err.Error())

--- a/protocol/v1/transport.go
+++ b/protocol/v1/transport.go
@@ -235,6 +235,10 @@ func (m *transportMessage) Version() string {
 
 // IsValidJSON validates the given JSON data against the Transport schema
 func (m *transportMessage) IsValidJSON(data string) (err error) {
+	if !protocol.ClientStrictValidation {
+		return nil
+	}
+
 	_, errors, err := schemas.Validate(schemas.TransportV1, data)
 	if err != nil {
 		err = fmt.Errorf("Could not validate Transport JSON data: %s", err.Error())


### PR DESCRIPTION
Before this every transport, secure reply and reply were fully JSON
schema validated

It was found that this on a 60k node set can consume about 2/3 of
the wall time, so since our clients in go will probably not be
general purpose I think custom clients can be given the choice to
disable that

So setting protocol.ClientStrictValidation to false will now hint
to protocol implimentations that this is not desired.  The v1 protocol
will not check this for transports, secure replies and replies

Servers always strict check