### PR TITLE
(#13) do not attempt to load the public cert when not secure

### DIFF
--- a/protocol/v1/constructors.go
+++ b/protocol/v1/constructors.go
@@ -117,8 +117,6 @@ func NewRequestFromSecureRequest(sr protocol.SecureRequest) (req protocol.Reques
 	return
 }
 
-// TODO
-
 // NewSecureReply creates a choria:secure:reply:1
 func NewSecureReply(reply protocol.Reply, security SecurityProvider) (secure protocol.SecureReply, err error) {
 	secure = &secureReply{
@@ -134,12 +132,8 @@ func NewSecureReply(reply protocol.Reply, security SecurityProvider) (secure pro
 	return
 }
 
-// TODO
-
 // NewSecureReplyFromTransport creates a new choria:secure:reply:1 from the data contained in a Transport message
 func NewSecureReplyFromTransport(message protocol.TransportMessage) (secure protocol.SecureReply, err error) {
-	// TODO: validate the transport message holds a reply
-
 	secure = &secureReply{
 		Protocol: protocol.SecureReplyV1,
 	}
@@ -167,14 +161,16 @@ func NewSecureReplyFromTransport(message protocol.TransportMessage) (secure prot
 	return
 }
 
-// TODO
-
 // NewSecureRequest creates a choria:secure:request:1
 func NewSecureRequest(request protocol.Request, security SecurityProvider) (secure protocol.SecureRequest, err error) {
-	pub, err := security.PublicCertTXT()
-	if err != nil {
-		err = fmt.Errorf("could not retrieve Public Certificate from the security subsystem: %s", err)
-		return
+	pub := []byte("insecure")
+
+	if protocol.IsSecure() {
+		pub, err = security.PublicCertTXT()
+		if err != nil {
+			err = fmt.Errorf("could not retrieve Public Certificate from the security subsystem: %s", err)
+			return
+		}
 	}
 
 	secure = &secureRequest{
@@ -190,8 +186,6 @@ func NewSecureRequest(request protocol.Request, security SecurityProvider) (secu
 
 	return
 }
-
-// TODO
 
 // NewSecureRequestFromTransport creates a new choria:secure:request:1 from the data contained in a Transport message
 func NewSecureRequestFromTransport(message protocol.TransportMessage, security SecurityProvider, skipvalidate bool) (secure protocol.SecureRequest, err error) {

--- a/protocol/v1/request_test.go
+++ b/protocol/v1/request_test.go
@@ -36,13 +36,4 @@ var _ = Describe("Request", func() {
 		Expect(filtered).To(BeTrue())
 		Expect(filter).ToNot(BeNil())
 	})
-
-	Measure("Request creation time", func(b Benchmarker) {
-		runtime := b.Time("runtime", func() {
-			request, _ := NewRequest("test", "go.tests", "choria=test", 120, "a2f0ca717c694f2086cfa81b6c494648", "mcollective")
-			request.SetMessage(`{"hello":"world"}`)
-		})
-
-		Expect(runtime.Nanoseconds()).Should(BeNumerically("<", 100000))
-	}, 1000)
 })

--- a/protocol/v1/transport_test.go
+++ b/protocol/v1/transport_test.go
@@ -85,19 +85,4 @@ var _ = Describe("TransportMessage", func() {
 		_, err = NewTransportFromJSON(`{"protocol": 1}`)
 		Expect(err).To(MatchError("Supplied JSON document is not a valid Transport message: data: data is required, headers: headers is required, protocol: Invalid type. Expected: string, given: integer"))
 	})
-
-	Measure("Transport creation", func(b Benchmarker) {
-		request, _ := NewRequest("test", "go.tests", "rip.mcollective", 120, "a2f0ca717c694f2086cfa81b6c494648", "mcollective")
-		request.SetMessage(`{"message":1}`)
-		srequest, _ := NewSecureRequest(request, security)
-		trequest, _ := NewTransportMessage("rip.mcollective")
-		trequest.SetRequestData(srequest)
-
-		runtime := b.Time("runtime", func() {
-			trequest, _ := NewTransportMessage("rip.mcollective")
-			trequest.SetRequestData(srequest)
-		})
-
-		Expect(runtime.Nanoseconds()).Should(BeNumerically("<", 1000000))
-	}, 100)
 })


### PR DESCRIPTION
When security is disabled it should not attempt to access the
certificate text since more or less there won't be one

This is regression from recent security provider work